### PR TITLE
Adding method for disapproving a comment

### DIFF
--- a/src/Comment.php
+++ b/src/Comment.php
@@ -43,6 +43,15 @@ class Comment extends Model
 
         return $this;
     }
+  
+    public function disapprove()
+    {
+        $this->update([
+            'is_approved' => false,
+        ]);
+
+        return $this;
+    }
 
     protected function getAuthModelName()
     {


### PR DESCRIPTION
Adding a method to disapprove comments.
example: 
 
```
$comment = $post->comments()->where('id',$commentId)->first();
$comment->disapprove();