### PR TITLE
Add support for laravel 5.8 default bigIncrement

### DIFF
--- a/database/migrations/create_comments_table.php.stub
+++ b/database/migrations/create_comments_table.php.stub
@@ -16,7 +16,7 @@ class CreateCommentsTable extends Migration
             $table->morphs('commentable');
             $table->text('comment');
             $table->boolean('is_approved')->default(false);
-            $table->unsignedInteger('user_id')->nullable();
+            $table->unsignedBigInteger('user_id')->nullable();
             $table->timestamps();
         });
     }


### PR DESCRIPTION
As `Laravel 5.8` default id is big increment. This PR edits comments `user_id` to be `unsignedBigInteger`.