### PR TITLE
Minimum required version Laravel 10.30

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
         }
     ],
     "require": {
-        "php": "^7.2.5|^8.0",
-        "illuminate/support": "~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0"
+        "php": "^8.1",
+        "illuminate/support": "^10.0|^11.0"
     },
     "require-dev": {
         "orchestra/testbench": "^3.6|^5.0|^6.0|^7.0|^8.0",
-        "phpunit/phpunit": "^7.0|^8.0|9.2.*|^9.5.10"
+        "phpunit/phpunit": "^9.5.8|^10.0.7"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
From version 1.6 with the added and deleted event handling with Laravel versions < 10.30 the error occurs due to the absence of the ShouldDispatchAfterCommit class introduced in Laravel 10.30 (https://laravel-news.com/laravel-10-30-0)

This PR simply modifies the composer.json with the minimum requirements of Laravel 10.30 and related (PHP 8.1, etc...)